### PR TITLE
Add platform info into cache key for compatibility

### DIFF
--- a/third_party/nvidia/backend/driver.py
+++ b/third_party/nvidia/backend/driver.py
@@ -45,8 +45,16 @@ def library_dirs():
     return [libdevice_dir, *libcuda_dirs()]
 
 
+@functools.lru_cache()
+def extra_cache_key():
+    # we need platform info (x86_64, aarch64 etc) to avoid incompatibility
+    # with the cached objects
+    from platform import machine, system, architecture
+    return ",".join([machine(), system(), *architecture()])
+
+
 def compile_module_from_src(src, name):
-    key = hashlib.sha256(src.encode("utf-8")).hexdigest()
+    key = hashlib.sha256((src + extra_cache_key()).encode("utf-8")).hexdigest()
     cache = get_cache_manager(key)
     cache_path = cache.get_file(f"{name}.so")
     if cache_path is None:


### PR DESCRIPTION
We have seen in a few cases, we're failing to load the shared object from the cache, because: 1. the cached object is built in aarch64 and we're trying to load it on a x86_64 machine (especially if we have remote cache); 2. if the cached object is built with e.g. ROCm 6.0 and we're loading it under ROCm 6.2. hip_utils.so will fail to load due to some ABI changes in the HIP runtime. Therefore, we'll need to add platform and HIP version info into the cache key.
